### PR TITLE
Allow out-of-source build directory to be located anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ add_document(
 )
 ~~~
 
+Deprecated syntax for backwards compatibility:
+~~~
+add_document(
+    opus.rtf
+    SOURCES opus.md
+    PRODUCT_DIRECTORY opus_output_directory
+)
+~~~
+
+
 ## Passing Directives to "`pandoc`"
 
 You have access to the full complexity of the Pandoc compiler through the "`PANDOC_DIRECTIVES`" argument, which will pass everything to the underlying "`pandoc`" program. So, for example, to generate a PDF with some custom options:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ INCLUDE(pandocology)
 
 The primary command offered by "Pandocology" is "`add_document()`".
 
-This command takes, at a mininum, two arguments: a *target name*, which specifies the output file (and, by inspection of the extension, the output file format), and at least one source file specifed by the "`SOURCES`" argument.
+This command takes, at a mininum, three arguments: a *target name*, an *output file name* which specifies the output file (and, by inspection of the extension, the output file format), and at least one source file specifed by the "`SOURCES`" argument.
 So, for example, if you had a Markdown format input file (say, "`opus.md`") that you wanted to convert to Rich Text Format, then the following is a minimal "`CMakeLists.txt`" to do that.
 
 ~~~
@@ -59,7 +59,8 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/cmake-pandocolo
 INCLUDE(pandocology)
 
 add_document(
-    opus.rtf
+    TARGET opus
+    OUTPUT_FILE opus.rtf
     SOURCES opus.md
 )
 ~~~
@@ -68,7 +69,8 @@ Once the project is built, the result "`opus.rtf`" will end up in the "`product`
 You can change the output directory by using the "`PRODUCT_DIRECTORY`" argument:
 ~~~
 add_document(
-    opus.rtf
+    TARGET opus
+    OUTPUT_FILE opus.rtf
     SOURCES opus.md
     PRODUCT_DIRECTORY opus_output_directory
 )
@@ -80,7 +82,8 @@ You have access to the full complexity of the Pandoc compiler through the "`PAND
 
 ~~~
 add_document(
-    opus.pdf
+    TARGET opus
+    OUTPUT_FILE opus.pdf
     SOURCES opus.md
     PANDOC_DIRECTIVES -t latex
                       --smart
@@ -99,7 +102,8 @@ These resources can be specified on a file-by-file basis using the "`RESOURCE_FI
 
 ~~~
 add_document(
-    opus.pdf
+    TARGET opus
+    OUTPUT_FILE opus.pdf
     SOURCES opus.md
     RESOURCE_FILES references.bib custom.template.latex journal.csl
     RESOURCE_DIRS  figures/ maps/
@@ -115,7 +119,7 @@ add_document(
 )
 ~~~
 
-**IMPORTANT NOTE:** When adding resources on a directory-basis using the `RESOURCE_DIRS` argument, all the resources that are in that directory *at the time* `cmake ..` is run are added as dependencies. The CMake system does not provide a way to monitor directories for changes, only files. Thus, if you add (or remove) files from any of the directories specified by the `RESOURCE_DIRS` argument, you will have to run `cmake ..` again to make sure that the build system adds (or removes) these files from the build specifications.
+**IMPORTANT NOTE:** When adding resources on a directory-basis using the `RESOURCE_DIRS` argument, all the resources that are in that directory *at the time* `cmake` is run are added as dependencies. The CMake system does not provide a way to monitor directories for changes, only files. Thus, if you add (or remove) files from any of the directories specified by the `RESOURCE_DIRS` argument, you will have to run `cmake ..` again to make sure that the build system adds (or removes) these files from the build specifications.
 
 ## Including Content After the Reference Section
 
@@ -125,7 +129,8 @@ The work-around is to create these post-reference sections as a separate documen
 You can support this workflow using Pandocology as follows:
 ~~~
 add_document(
-    appendices.tex
+    TARGET               appendices
+    OUTPUT_FILE          appendices.tex
     SOURCES              appendices.md
     RESOURCE_DIRS        appendix-figs
     PANDOC_DIRECTIVES    -t latex
@@ -133,7 +138,8 @@ add_document(
     )
 
 add_document(
-    opus.pdf
+    TARGET              opus
+    OUTPUT_FILE         opus.pdf
     SOURCES             opus.md
     RESOURCE_FILES      references.bib custom.template.latex journal.csl
     RESOURCE_DIRS       figures/ maps/
@@ -145,7 +151,7 @@ add_document(
                         --csl          journal.csl
                         --bibliography references.bib
                         --include-after-body=appendices.tex
-    DEPENDS             appendices.tex
+    DEPENDS             appendices
     )
 ~~~
 
@@ -156,7 +162,7 @@ By specifying "`NO_EXPORT_PRODUCT`", we are suppressing the final step, and thus
 
 The second instruction builds the primary output that we are interested in, i.e., "`opus.pdf`", from the (Markdown) source "`opus.md`".
 Note how we specify the "`--include-after-body=appendices.tex`" argument to "`pandoc`", to make sure the Pandoc compiler pulls in the generated TeX file into the main document.
-In addition, we also list "`appendices.tex`" as a dependency using the "`DEPENDS`" argument.
+In addition, we also list "`appendices`" as a dependency using the "`DEPENDS`" argument.
 This results in Pandocology informing the CMake build system that "`appendices.tex`" will be used in the building of "`opus.pdf`".
 This is how we make sure that built or generated resources are available in the right place at the right time (as opposed to the "`RESOURCE_FILES`" and "`RESOURCE_DIRS`" arguments, which make sure that *static* resources get to the right places at the right time).
 Of course, as before, we make sure to specify all the static resources that this document needs (e.g. the bibliography file, the templates, the images in the "`figures/`" and "`maps/`" subdirectories).
@@ -168,7 +174,8 @@ You can do this by specifying the "`EXPORT_ARCHIVE`" flag, which will create a c
 
 ~~~
 add_document(
-    appendices.tex
+    TARGET               appendices
+    OUTPUT_FILE          appendices.tex
     SOURCES              appendices.md
     RESOURCE_DIRS        appendix-figs
     PANDOC_DIRECTIVES    -t latex
@@ -176,7 +183,8 @@ add_document(
     )
 
 add_document(
-    opus.tex
+    TARGET              opus
+    OUTPUT_FILE         opus.tex
     SOURCES             opus.md
     RESOURCE_FILES      references.bib custom.template.latex journal.csl
     RESOURCE_DIRS       figures/ maps/
@@ -188,7 +196,7 @@ add_document(
                         --csl          journal.csl
                         --bibliography references.bib
                         --include-after-body=appendices.tex
-    DEPENDS             appendices.tex
+    DEPENDS             appendices
     EXPORT_ARCHIVE
     )
 ~~~
@@ -198,7 +206,8 @@ In the above case, once run, the output directory will not only have the primary
 If you want *just* the archive (which include the primary product, i.e., "`opus.tex`" in the example above), and not the primary file to be created in the output directory, then specify "`EXPORT_ARCHIVE`" and "`NO_EXPORT_PRODUCT`" together. The former creates the archive and the latter suppresses the creation of a separate (and perhaps, for your purposes, redundant) output.
 ~~~
 add_document(
-    opus.tex
+    TARGET              opus
+    OUTPUT_FILE         opus.tex
     SOURCES             opus.md
     RESOURCE_FILES      references.bib custom.template.latex journal.csl
     RESOURCE_DIRS       figures/ maps/
@@ -210,7 +219,7 @@ add_document(
                         --csl          journal.csl
                         --bibliography references.bib
                         --include-after-body=appendices.tex
-    DEPENDS             appendices.tex
+    DEPENDS             appendices
     NO_EXPORT_PRODUCT
     EXPORT_ARCHIVE
     )
@@ -228,7 +237,8 @@ The way to do this using Pandocology is to:
 
 ~~~
 add_document(
-    appendices.tex
+    TARGET               appendices
+    OUTPUT_FILE          appendices.tex
     SOURCES              appendices.md
     RESOURCE_DIRS        appendix-figs
     PANDOC_DIRECTIVES    -t latex
@@ -236,7 +246,8 @@ add_document(
     )
 
 add_document(
-    opus.tex
+    TARGET               opus
+    OUTPUT_FILE          opus.tex
     SOURCES              opus.md
     RESOURCE_FILES       references.bib custom.template.latex journal.csl
     RESOURCE_DIRS        figs
@@ -248,7 +259,7 @@ add_document(
                         --csl          journal.csl
                         --bibliography references.bib
                         --include-after-body=appendices.tex
-    DEPENDS             appendices.tex
+    DEPENDS             appendices
     NO_EXPORT_PRODUCT
     EXPORT_ARCHIVE
     EXPORT_PDF
@@ -266,7 +277,8 @@ If you have a a TeX or a LaTeX project, and you want to generate the final PDF's
 
 ~~~
 add_document(
-    opus.pdf
+    TARGET               opus
+    OUTPUT_FILE          opus.pdf
     SOURCES              opus.tex
     RESOURCE_FILES       opus.bib figures.tex sysbio.bst
     RESOURCE_DIRS        figs
@@ -281,7 +293,8 @@ For convenience (mnemonic as much as operational), you can call the function ``a
 
 ~~~
 add_tex_document(
-    opus.pdf
+    TARGET               opus
+    OUTPUT_FILE          opus.pdf
     SOURCES              opus.tex
     RESOURCE_FILES       opus.bib figures.tex sysbio.bst
     RESOURCE_DIRS        figs

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ project/
     src/
 ~~~
 
-you might place this file "`pandocology.cmake` in "`project/cmake/Modules`", and then add a line like the following either in the top-level "`CMakeLists.txt`" or any other "`CMakeLists.txt`" processed before the commands provided by "Pandocology" are needed:
+ou might place the file "`pandocology.cmake` in "`project/cmake/Modules`", and then add a line like the following either in the top-level "`CMakeLists.txt`" or any other "`CMakeLists.txt`" processed before the commands provided by "Pandocology" are needed:
 
 ~~~
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
@@ -35,7 +35,7 @@ $ cd cmake/Modules
 $ git submodule add https://github.com/jeetsukumaran/cmake-pandocology.git
 ~~~
 
-And I added the following line to my top-level "`CMakeLists.txt`":
+Then, I added the following line to my top-level "`CMakeLists.txt`":
 
 ~~~
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/cmake-pandocology")
@@ -93,7 +93,7 @@ add_document(
 ## Including Static Resources
 
 In many cases your inputs are going to be more than just the primary source document: images, CSS stylesheets, BibTeX bibliography database files, stylesheets, templates etc.
-All these secondary files or inputs that are not the primary input to the "`pandoc`" program but are required to compile the main document are known as "*resources*".
+All these secondary files or inputs that are not the primary input to the "`pandoc`" program, but are required to compile the main document, are known as "*resources*".
 
 These resources can be specified on a file-by-file basis using the "`RESOURCE_FILES`" argument and on a directory-by-directory basis using the "`RESOURCE_DIRS`" argument (note that all paths are relative to the current source directory):
 
@@ -115,7 +115,7 @@ add_document(
 )
 ~~~
 
-**IMPORTANT NOTE:** When adding resources on a directory-bases using the `RESOURCE_DIRS` argument, all the resources that are in that directory *at the time* `cmake ..` is run are added as dependencies. The CMake system does not provide a way to monitor directories for changes, only files. Thus, if you add (or remove) files from any of the directories specified by the `RESOURCE_DIRS` argument, you will have to run `cmake ..` again to make sure that the build system adds (or removes) these files from the build specifications.
+**IMPORTANT NOTE:** When adding resources on a directory-basis using the `RESOURCE_DIRS` argument, all the resources that are in that directory *at the time* `cmake ..` is run are added as dependencies. The CMake system does not provide a way to monitor directories for changes, only files. Thus, if you add (or remove) files from any of the directories specified by the `RESOURCE_DIRS` argument, you will have to run `cmake ..` again to make sure that the build system adds (or removes) these files from the build specifications.
 
 ## Including Content After the Reference Section
 

--- a/pandocology.cmake
+++ b/pandocology.cmake
@@ -164,7 +164,8 @@ endfunction()
 #         )
 #
 #     add_document(
-#         OUTPUT_FILE         opus.pdf
+#         TARGET               opus
+#         OUTPUT_FILE          opus.pdf
 #         SOURCES              opus.md
 #         RESOURCE_FILES       opus.bib systbiol.template.latex systematic-biology.csl
 #         RESOURCE_DIRS        figs

--- a/pandocology.cmake
+++ b/pandocology.cmake
@@ -63,21 +63,25 @@ endif()
 # Adds command to copy file from the source directory to the destination
 # directory: used to move source files from source directory into build
 # directory before main build
-function(pandocology_add_input_file source_path dest_dir dest_filelist_var)
+function(pandocology_add_input_file source_path dest_dir dest_filelist_var native_dest_filelist_var)
     set(dest_filelist)
+    set(native_dest_filelist)
     file(GLOB globbed_source_paths "${source_path}")
     foreach(globbed_source_path ${globbed_source_paths})
-        # MESSAGE(FATAL_ERROR "${globbed_source_path}")
         get_filename_component(filename ${globbed_source_path} NAME)
         get_filename_component(absolute_dest_path ${dest_dir}/${filename} ABSOLUTE)
         file(RELATIVE_PATH relative_dest_path ${CMAKE_CURRENT_BINARY_DIR} ${absolute_dest_path})
         list(APPEND dest_filelist ${absolute_dest_path})
+        file(TO_NATIVE_PATH ${absolute_dest_path} native_dest_path)
+        list(APPEND native_dest_filelist ${native_dest_path})
+        file(TO_NATIVE_PATH ${globbed_source_path} native_globbed_source_path)
         ADD_CUSTOM_COMMAND(
             OUTPUT ${relative_dest_path}
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${globbed_source_path} ${dest_dir}/${filename}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${native_globbed_source_path} ${native_dest_path}
             DEPENDS ${globbed_source_path}
             )
         set(${dest_filelist_var} ${${dest_filelist_var}} ${dest_filelist} PARENT_SCOPE)
+        set(${native_dest_filelist_var} ${${native_dest_filelist_var}} ${native_dest_filelist} PARENT_SCOPE)
     endforeach()
 endfunction()
 
@@ -98,28 +102,32 @@ function(pandocology_get_file_extension varname filename)
 endfunction()
 ###############################################################################
 
-function(pandocology_add_input_dir source_dir dest_parent_dir dir_dest_filelist_var)
+function(pandocology_add_input_dir source_dir dest_parent_dir dir_dest_filelist_var native_dir_dest_filelist_var)
     set(dir_dest_filelist)
+    set(native_dir_dest_filelist)
     file(TO_CMAKE_PATH ${source_dir} source_dir)
     get_filename_component(dir_name ${source_dir} NAME)
     get_filename_component(absolute_dest_dir ${dest_parent_dir}/${dir_name} ABSOLUTE)
     file(RELATIVE_PATH relative_dest_dir ${CMAKE_CURRENT_BINARY_DIR} ${absolute_dest_dir})
+    file(TO_NATIVE_PATH ${absolute_dest_dir} native_absolute_dest_dir)
     add_custom_command(
         OUTPUT ${relative_dest_dir}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${absolute_dest_dir}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${native_absolute_dest_dir}
         DEPENDS ${source_dir}
         )
     file(GLOB source_files "${source_dir}/*")
     foreach(source_file ${source_files})
         # get_filename_component(absolute_source_path ${CMAKE_CURRENT_SOURCE_DIR}/${source_file} ABSOLUTE)
-        pandocology_add_input_file(${source_file} ${absolute_dest_dir} dir_dest_filelist)
+        pandocology_add_input_file(${source_file} ${absolute_dest_dir} dir_dest_filelist native_dir_dest_filelist)
     endforeach()
     set(${dir_dest_filelist_var} ${${dir_dest_filelist_var}} ${dir_dest_filelist} PARENT_SCOPE)
+    set(${native_dir_dest_filelist_var} ${${native_dir_dest_filelist_var}} ${native_dir_dest_filelist} PARENT_SCOPE)
 endfunction()
 
 function(add_to_make_clean filepath)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${filepath} native_filepath)
     get_directory_property(make_clean_files ADDITIONAL_MAKE_CLEAN_FILES)
-    set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${make_clean_files};${filepath}")
+    set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${make_clean_files};${native_filepath}")
 endfunction()
 
 function(disable_insource_build)
@@ -188,28 +196,34 @@ function(add_document)
         MESSAGE(FATAL_ERROR "add_document() requires an output file name by using the OUTPUT_FILE option")
     endif()
 
+    set(output_file ${ADD_DOCUMENT_OUTPUT_FILE})
+    file(TO_NATIVE_PATH ${output_file} native_output_file)
+
     # get the stem of the target name
-    pandocology_get_file_stemname(target_stemname ${ADD_DOCUMENT_OUTPUT_FILE})
-    pandocology_get_file_extension(target_extension ${ADD_DOCUMENT_OUTPUT_FILE})
+    pandocology_get_file_stemname(output_file_stemname ${output_file})
+    pandocology_get_file_extension(output_file_extension ${output_file})
+
     if (${ADD_DOCUMENT_EXPORT_PDF})
-        if (NOT "${target_extension}" STREQUAL ".tex" AND NOT "${target_extension}" STREQUAL ".latex")
-        # if (NOT "${target_extension}" STREQUAL ".tex")
-            MESSAGE(FATAL_ERROR "Target '${ADD_DOCUMENT_TARGET}': Cannot use 'EXPORT_PDF' for target of type '${target_extension}': target type must be '.tex' or '.latex'")
+        if (NOT "${output_file_extension}" STREQUAL ".tex" AND NOT "${output_file_extension}" STREQUAL ".latex")
+            MESSAGE(FATAL_ERROR "Target '${ADD_DOCUMENT_TARGET}': Cannot use 'EXPORT_PDF' for target of type '${output_file_extension}': target type must be '.tex' or '.latex'")
         endif()
     endif()
+
     if (${ADD_DOCUMENT_DIRECT_TEX_TO_PDF})
         list(LENGTH ${ADD_DOCUMENT_SOURCES} SOURCE_LEN)
         if (SOURCE_LEN GREATER 1)
             MESSAGE(FATAL_ERROR "Target '${ADD_DOCUMENT_TARGET}': Only one source can be specified when using the 'DIRECT_TEX_TO_PDF' option")
         endif()
-        # set(ADD_DOCUMENT_SOURCES, list(GET ${ADD_DOCUMENT_SOURCES} 1))
+
         pandocology_get_file_stemname(source_stemname ${ADD_DOCUMENT_SOURCES})
         pandocology_get_file_extension(source_extension ${ADD_DOCUMENT_SOURCES})
+
         if (NOT "${source_extension}" STREQUAL ".tex" AND NOT "${source_extension}" STREQUAL ".latex")
             MESSAGE(FATAL_ERROR "Target '${ADD_DOCUMENT_TARGET}': Cannot use 'DIRECT_TEX_TO_PDF' for source of type '${source_extension}': source type must be '.tex' or '.latex'")
         endif()
-        SET(check_target ${source_stemname}.pdf)
-        IF (NOT ${check_target} STREQUAL ${ADD_DOCUMENT_OUTPUT_FILE})
+
+        set(check_target ${source_stemname}.pdf)
+        if (NOT ${check_target} STREQUAL ${output_file})
             MESSAGE(FATAL_ERROR "Target '${ADD_DOCUMENT_TARGET}': Must use target name of '${check_target}' if using 'DIRECT_TEX_TO_PDF'")
         endif()
     endif()
@@ -218,27 +232,34 @@ function(add_document)
     if ("${ADD_DOCUMENT_PRODUCT_DIRECTORY}" STREQUAL "")
         set(ADD_DOCUMENT_PRODUCT_DIRECTORY "product")
     endif()
+
     get_filename_component(product_directory ${CMAKE_BINARY_DIR}/${ADD_DOCUMENT_PRODUCT_DIRECTORY} ABSOLUTE)
-    # get_filename_component(absolute_product_path ${product_directory}/${ADD_DOCUMENT_OUTPUT_FILE} ABSOLUTE)
+    file(TO_NATIVE_PATH ${product_directory} native_product_directory)
+
+    set(dest_output_file ${product_directory}/${output_file})
+    file(TO_NATIVE_PATH ${dest_output_file} native_dest_output_file)
 
     ## get primary source
     set(build_sources)
+    set(native_build_sources)
     foreach(input_file ${ADD_DOCUMENT_SOURCES} )
-        pandocology_add_input_file(${CMAKE_CURRENT_SOURCE_DIR}/${input_file} ${CMAKE_CURRENT_BINARY_DIR} build_sources)
+        pandocology_add_input_file(${CMAKE_CURRENT_SOURCE_DIR}/${input_file} ${CMAKE_CURRENT_BINARY_DIR} build_sources native_build_sources)
     endforeach()
 
     ## get resource files
     set(build_resources)
+    set(native_build_resources)
     foreach(resource_file ${ADD_DOCUMENT_RESOURCE_FILES})
-        pandocology_add_input_file(${CMAKE_CURRENT_SOURCE_DIR}/${resource_file} ${CMAKE_CURRENT_BINARY_DIR} build_resources)
+        pandocology_add_input_file(${CMAKE_CURRENT_SOURCE_DIR}/${resource_file} ${CMAKE_CURRENT_BINARY_DIR} build_resources native_build_resources)
     endforeach()
 
     ## get resource dirs
     set(exported_resources)
+    set(native_exported_resources)
     foreach(resource_dir ${ADD_DOCUMENT_RESOURCE_DIRS})
-        pandocology_add_input_dir(${CMAKE_CURRENT_SOURCE_DIR}/${resource_dir} ${CMAKE_CURRENT_BINARY_DIR} build_resources)
+        pandocology_add_input_dir(${CMAKE_CURRENT_SOURCE_DIR}/${resource_dir} ${CMAKE_CURRENT_BINARY_DIR} build_resources native_build_resources)
         if (${ADD_DOCUMENT_EXPORT_ARCHIVE})
-            pandocology_add_input_dir(${CMAKE_CURRENT_SOURCE_DIR}/${resource_dir} ${product_directory} exported_resources)
+            pandocology_add_input_dir(${CMAKE_CURRENT_SOURCE_DIR}/${resource_dir} ${product_directory} exported_resources native_exported_resources)
         endif()
     endforeach()
 
@@ -246,50 +267,43 @@ function(add_document)
     if (${ADD_DOCUMENT_DIRECT_TEX_TO_PDF})
         if (${ADD_DOCUMENT_VERBOSE})
             add_custom_command(
-                OUTPUT  ${ADD_DOCUMENT_OUTPUT_FILE} # note that this is in the build directory
+                OUTPUT  ${output_file} # note that this is in the build directory
                 DEPENDS ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
-                # WORKING_DIRECTORY ${working_directory}
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${product_directory}
-                # we produce the target in the source directory, in case other build targets require it as a source
-                COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode -file-line-error -pdf ${build_sources}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${native_product_directory}
+                COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode -file-line-error -pdf ${native_build_sources}
                 )
         else()
             add_custom_command(
-              OUTPUT  ${ADD_DOCUMENT_OUTPUT_FILE} # note that this is in the build directory
+              OUTPUT  ${output_file} # note that this is in the build directory
                 DEPENDS ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
-                # WORKING_DIRECTORY ${working_directory}
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${product_directory}
-                # we produce the target in the source directory, in case other build targets require it as a source
-                COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode -file-line-error -pdf ${build_sources} 2>/dev/null >/dev/null || (grep --no-messages -A8 ".*:[0-9]*:.*" ${target_stemname}.log && false)
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${native_product_directory}
+                COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode -file-line-error -pdf ${native_build_sources} 2>/dev/null >/dev/null || (grep --no-messages -A8 ".*:[0-9]*:.*" ${output_file_stemname}.log && false)
                 )
         endif()
-        add_to_make_clean(${CMAKE_CURRENT_BINARY_DIR}/${ADD_DOCUMENT_OUTPUT_FILE})
+        add_to_make_clean(${output_file})
     else()
         add_custom_command(
-            OUTPUT  ${ADD_DOCUMENT_OUTPUT_FILE} # note that this is in the build directory
+            OUTPUT  ${output_file} # note that this is in the build directory
             DEPENDS ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
-            # WORKING_DIRECTORY ${working_directory}
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${product_directory}
-            # we produce the target in the source directory, in case other build targets require it as a source
-            COMMAND ${PANDOC_EXECUTABLE} ${build_sources}
-            ${ADD_DOCUMENT_PANDOC_DIRECTIVES} -o ${ADD_DOCUMENT_OUTPUT_FILE}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${native_product_directory}
+            COMMAND ${PANDOC_EXECUTABLE} ${native_build_sources} ${ADD_DOCUMENT_PANDOC_DIRECTIVES} -o ${native_output_file}
             )
-        add_to_make_clean(${CMAKE_CURRENT_BINARY_DIR}/${ADD_DOCUMENT_OUTPUT_FILE})
+        add_to_make_clean(${output_file})
     endif()
 
     ## figure out what all is going to be produced by this build set, and set
     ## those as dependencies of the primary target
     set(primary_target_dependencies)
-    set(primary_target_dependencies ${primary_target_dependencies} ${CMAKE_CURRENT_BINARY_DIR}/${ADD_DOCUMENT_OUTPUT_FILE})
+    set(primary_target_dependencies ${primary_target_dependencies} ${CMAKE_CURRENT_BINARY_DIR}/${output_file})
     if (NOT ${ADD_DOCUMENT_NO_EXPORT_PRODUCT})
-        set(primary_target_dependencies ${primary_target_dependencies} ${product_directory}/${ADD_DOCUMENT_OUTPUT_FILE})
+        set(primary_target_dependencies ${primary_target_dependencies} ${product_directory}/${output_file})
     endif()
     if (${ADD_DOCUMENT_EXPORT_PDF})
-        set(primary_target_dependencies ${primary_target_dependencies} ${CMAKE_CURRENT_BINARY_DIR}/${target_stemname}.pdf)
-        set(primary_target_dependencies ${primary_target_dependencies} ${product_directory}/${target_stemname}.pdf)
+        set(primary_target_dependencies ${primary_target_dependencies} ${CMAKE_CURRENT_BINARY_DIR}/${output_file_stemname}.pdf)
+        set(primary_target_dependencies ${primary_target_dependencies} ${product_directory}/${output_file_stemname}.pdf)
     endif()
     if (${ADD_DOCUMENT_EXPORT_ARCHIVE})
-        set(primary_target_dependencies ${primary_target_dependencies} ${product_directory}/${target_stemname}.tbz)
+        set(primary_target_dependencies ${primary_target_dependencies} ${product_directory}/${output_file_stemname}.tbz)
     endif()
 
     ## primary target
@@ -303,13 +317,12 @@ function(add_document)
 
     # run post-pdf
     if (${ADD_DOCUMENT_EXPORT_PDF})
-        # get_filename_component(target_stemname ${ADD_DOCUMENT_OUTPUT_FILE} NAME_WE)
         add_custom_command(
-            OUTPUT ${product_directory}/${target_stemname}.pdf ${CMAKE_CURRENT_BINARY_DIR}/${target_stemname}.pdf
-            DEPENDS ${ADD_DOCUMENT_OUTPUT_FILE} ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
+            OUTPUT ${native_product_directory}/${output_file_stemname}.pdf ${CMAKE_CURRENT_BINARY_DIR}/${output_file_stemname}.pdf
+            DEPENDS ${output_file} ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
 
             # Does not work: custom template used to generate tex is ignored
-            # COMMAND ${PANDOC_EXECUTABLE} ${ADD_DOCUMENT_OUTPUT_FILE} -f latex -o ${target_stemname}.pdf
+            # COMMAND ${PANDOC_EXECUTABLE} ${output_file} -f latex -o ${output_file_stemname}.pdf
 
             # (1)   Apparently, both nonstopmode and batchmode produce an output file
             #       even if there was an error. This tricks latexmk into believing
@@ -327,48 +340,37 @@ function(add_document)
             #       So we can have our cake and eat it too: here we want to
             #       re-raise the error after a successful grep if there was an
             #       error in `latexmk`.
-            # COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode # -file-line-error -pdf ${ADD_DOCUMENT_OUTPUT_FILE} 2>&1 | grep -A8 ".*:[0-9]*:.*" || true
-            COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode -file-line-error -pdf ${ADD_DOCUMENT_OUTPUT_FILE} 2>/dev/null >/dev/null || (grep --no-messages -A8 ".*:[0-9]*:.*" ${target_stemname}.log && false)
+            # COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode # -file-line-error -pdf ${output_file} 2>&1 | grep -A8 ".*:[0-9]*:.*" || true
+            COMMAND latexmk -gg -halt-on-error -interaction=nonstopmode -file-line-error -pdf ${native_output_file} 2>/dev/null >/dev/null || (grep --no-messages -A8 ".*:[0-9]*:.*" ${output_file_stemname}.log && false)
 
-            COMMAND ${CMAKE_COMMAND} -E copy ${target_stemname}.pdf ${product_directory}
+            COMMAND ${CMAKE_COMMAND} -E copy ${output_file_stemname}.pdf ${native_product_directory}
             )
-        add_to_make_clean(${CMAKE_CURRENT_BINARY_DIR}/${target_stemname}.pdf)
-        add_to_make_clean(${product_directory}/${target_stemname}.pdf)
+        add_to_make_clean(${output_file_stemname}.pdf)
+        add_to_make_clean(${product_directory}/${output_file_stemname}.pdf)
     endif()
 
     ## copy products
     if (NOT ${ADD_DOCUMENT_NO_EXPORT_PRODUCT})
         add_custom_command(
-            OUTPUT ${product_directory}/${ADD_DOCUMENT_OUTPUT_FILE}
+            OUTPUT ${native_dest_output_file}
             DEPENDS ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ADD_DOCUMENT_OUTPUT_FILE} ${product_directory}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${native_output_file} ${native_dest_output_file}
             )
-        add_to_make_clean(${product_directory}/${ADD_DOCUMENT_OUTPUT_FILE})
+        add_to_make_clean(${product_directory}/${output_file})
     endif()
 
     ## copy resources
-    if (${ADD_DOCUMENT_EXPORT_ARCHIVE})
-        # get_filename_component(target_stemname ${ADD_DOCUMENT_OUTPUT_FILE} NAME_WE)
-        # add_custom_command(
-        #     TARGET ${ADD_DOCUMENT_OUTPUT_FILE} POST_BUILD
-        #     DEPENDS ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
-        #     # COMMAND cp ${build_resources} ${ADD_DOCUMENT_DEPENDS} ${product_directory}
-        #     COMMAND ${CMAKE_COMMAND} -E tar cjf ${product_directory}/${target_stemname}.tbz ${ADD_DOCUMENT_OUTPUT_FILE} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
-        #     )
-        add_custom_command(
-            OUTPUT ${product_directory}/${target_stemname}.tbz
-            DEPENDS ${ADD_DOCUMENT_OUTPUT_FILE}
-            # COMMAND cp ${build_resources} ${ADD_DOCUMENT_DEPENDS} ${product_directory}
-            COMMAND ${CMAKE_COMMAND} -E tar cjf ${product_directory}/${target_stemname}.tbz ${ADD_DOCUMENT_OUTPUT_FILE} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
-            )
-        add_to_make_clean(${product_directory}/${target_stemname}.tbz)
-        # add_custom_target(
-        #     ${target_stemname}.ARCHIVE
-        #     ALL
-        #     DEPENDS ${product_directory}/${target_stemname}.tbz
-        #     )
-    endif()
+    set(export_archive_file ${product_directory}/${output_file_stemname}.tbz)
+    file(TO_NATIVE_PATH ${export_archive_file} native_export_archive_file)
 
+    if (${ADD_DOCUMENT_EXPORT_ARCHIVE})
+        add_custom_command(
+            OUTPUT ${export_archive_file}
+            DEPENDS ${output_file}
+            COMMAND ${CMAKE_COMMAND} -E tar cjf ${native_export_archive_file} ${native_output_file} ${native_build_resources} ${ADD_DOCUMENT_DEPENDS}
+            )
+        add_to_make_clean(${export_archive_file})
+    endif()
 endfunction(add_document)
 
 function(add_tex_document)


### PR DESCRIPTION
This patch mainly addresses recurring issues #1, #5 and #6  which do not permit the out-of-source build directory to be located anywhere on the file system. The culprit is the usage of the output file name also as the name of the custom target.

I had a similar issue when I was developing my [cmake LLVM IR utilities](https://github.com/compor/llvm-ir-cmake-utils). The cleanest solution is to provide a target name and be also able to tune the output file name, just like most of `add_` `cmake` commands do. For this reason, the corresponding `TARGET` and `OUTPUT_FILE` options were added.

The test directory where I'm using the above changes can be found [here](https://github.com/compor/uoe-inf-thesis-skeleton).

Moreover, the following have been addressed/changed/fixed:

- update documentation
- convert any use of paths on external commands using `file(TO_NATIVE_PATH)` command
