### PR TITLE
add master branch tracking to git submodule command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 In my own case, I have cloned this entire repository as a submodule of my project module:
 ~~~
 $ cd cmake/Modules
-$ git submodule add https://github.com/jeetsukumaran/cmake-pandocology.git
+$ git submodule add -b master https://github.com/jeetsukumaran/cmake-pandocology.git
 ~~~
 
 Then, I added the following line to my top-level "`CMakeLists.txt`":


### PR DESCRIPTION
It's a good idea to explicitly state the branch for submodules. You could also add hint at `git submodule update --remote --init --recursive` for regular updates.