### PR TITLE
PREPROCESS: Run pp  independent of CMAKE_SOURCE_DIR

### DIFF
--- a/pandocology.cmake
+++ b/pandocology.cmake
@@ -349,7 +349,7 @@ function(add_document)
                         DEPENDS ${build_sources} ${build_resources} ${ADD_DOCUMENT_DEPENDS}
                         COMMAND ${PP_EXECUTABLE} ${ADD_DOCUMENT_PP_DIRECTIVES} ${native_build_source} > ${preprocessed_output_filepath}
                         VERBATIM
-                        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                        WORKING_DIRECTORY ${pp_working_directory}
                     )
                     add_to_make_clean(${preprocessed_build_source})
                     list(APPEND preprocessed_build_sources ${preprocessed_build_source})


### PR DESCRIPTION
A little embarassing but it did not turn up in my setup:

Currently pp is run in the CMAKE_SOURCE_DIR, which can cause problems with documents in subdirs. I had the solution already in place, but forgot to commit. Here it is now.

Cheers,

Jörn