### PR TITLE
add missing endif()

### DIFF
--- a/pandocology.cmake
+++ b/pandocology.cmake
@@ -307,6 +307,7 @@ function(add_document)
           pandocology_add_input_file(${resource_file} ${CMAKE_CURRENT_BINARY_DIR} build_resources native_build_resources)
         else()
           pandocology_add_input_file(${CMAKE_CURRENT_SOURCE_DIR}/${resource_file} ${CMAKE_CURRENT_BINARY_DIR} build_resources native_build_resources)
+        endif()  
     endforeach()
 
     ## get resource dirs


### PR DESCRIPTION
With newer cmake versions this file won't be accepted and terminates with an error message 

```
CMake Error at deps/cmake_pandocology-src/pandocology.cmake:310 (endforeach):
  Flow control statements are not properly nested.
```

This change fixes that